### PR TITLE
S3 Version 0.4.2 of remote_backend

### DIFF
--- a/s3/remote_backend/main.tf
+++ b/s3/remote_backend/main.tf
@@ -3,10 +3,10 @@
 
 resource "aws_s3_bucket" "this" {
   # Bucket name needs to be unique can include optional suffix
-  bucket = bucket_suffix == null ? var.bucket : "${var.bucket}-${var.bucket_suffix}"
+  bucket = var.bucket_suffix == null ? var.bucket : "${var.bucket}-${var.bucket_suffix}"
   
   tags = {
-    Version = "0.4.2"
+    Version = "0.4.3"
     Encryption = var.encryption
   }
 


### PR DESCRIPTION
fixed invalid reference bug by adding var infront of bucket_suffix